### PR TITLE
Add support for `.qmd` files

### DIFF
--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -211,7 +211,7 @@ add_contribs_to_files <- function (ctbs, orgrepo, ncols, format, files,
 
     # files <- file.path (here::here(), files)
     files <- files [which (file.exists (files))]
-    files <- files [grep ("\\.md$|\\.Rmd$", files)]
+    files <- files [grep ("\\.md$|\\.Rmd$|\\.qmd$", files)]
 
     if (length (files) == 0) {
         stop ("None of theose files exist, or are either '.Rmd' or '.md' files")

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -211,7 +211,7 @@ add_contribs_to_files <- function (ctbs, orgrepo, ncols, format, files,
 
     # files <- file.path (here::here(), files)
     files <- files [which (file.exists (files))]
-    files <- files [grep ("\\.md$|\\.Rmd$|\\.qmd$", files)]
+    files <- files [grep ("\\.md$|\\.Rmd$|\\.[Q|q]md$", files)]
 
     if (length (files) == 0) {
         stop ("None of theose files exist, or are either '.Rmd' or '.md' files")


### PR DESCRIPTION
Love the fact that y'all ported all contributors to an R package! This PR adds support for `.qmd` files, which are used throughout Quarto. 

I wanted to use your package in a Quarto project, and noticed that the package failed to add the table to a `.qmd` file. Upon inspecting the code, I quickly found the way to address this. I tested it locally and was able to add the contributor table to my Quarto project.

Thanks for being so organized that this was an easy addition. I of course understand if you do not merge this, and am opening this PR for your consideration only.