### PR TITLE
Add feature to scan multiple paths at once

### DIFF
--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -85,7 +85,7 @@ add_contributors <- function (repo = ".",
     all_repos <- list(ctbs = data.frame())
 
     for (rep in repo) {
-        one_repo <- add_contributors_one_repo(
+        one_repo <- get_contributors_one_repo(
                               repo = rep,
                               type,
                               exclude_label,
@@ -112,7 +112,7 @@ add_contributors <- function (repo = ".",
     invisible (unlist (chk))
 }
 
-add_contributors_one_repo <- function (
+get_contributors_one_repo <- function (
                               repo,
                               type,
                               exclude_label,

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -2,8 +2,8 @@
 #'
 #' Add contributors to README.Rmd
 #'
-#' @param repo Location of repository for which contributions are to be
-#' extracted. This must be a git project with a github remote.
+#' @param repo Vector of repository locations for which contributions are to be
+#' extracted. Each location must be a git project with a github remote.
 #' @param ncols Number of columns for contributors in 'README'
 #' @param files Names of files in which to add contributors
 #' @param type Type of contributions to include: 'code' for direct code
@@ -81,7 +81,36 @@ add_contributors <- function (repo = ".",
                               alphabetical = FALSE,
                               open_issue = FALSE,
                               force_update = FALSE) {
+    ctbs <- add_contributors_one_repo(
+                              repo,
+                              type,
+                              exclude_label,
+                              exclude_issues,
+                              exclude_not_planned,
+                              num_sections,
+                              section_names,
+                              format,
+                              alphabetical
+    )
 
+    chk <- add_contribs_to_files (
+        ctbs$ctbs, ctbs$or, ncols, format, files,
+        open_issue, force_update
+    )
+
+    invisible (unlist (chk))
+}
+
+add_contributors_one_repo <- function (
+                              repo,
+                              type,
+                              exclude_label,
+                              exclude_issues,
+                              exclude_not_planned,
+                              num_sections,
+                              section_names,
+                              format,
+                              alphabetical) {
     if (!in_git_repository (repo)) {
         stop ("The path [", repo, "] does not appear to be a git repository")
     }
@@ -136,12 +165,7 @@ add_contributors <- function (repo = ".",
 
     ctbs <- rename_default_sections (ctbs)
 
-    chk <- add_contribs_to_files (
-        ctbs, or, ncols, format, files,
-        open_issue, force_update
-    )
-
-    invisible (unlist (chk))
+    return(list(ctbs, or))
 }
 
 match_type_arg <- function (type) {

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -81,8 +81,12 @@ add_contributors <- function (repo = ".",
                               alphabetical = FALSE,
                               open_issue = FALSE,
                               force_update = FALSE) {
-    ctbs <- add_contributors_one_repo(
-                              repo,
+    # Init list
+    all_repos <- list(ctbs = data.frame())
+
+    for (rep in repo) {
+        one_repo <- add_contributors_one_repo(
+                              repo = rep,
                               type,
                               exclude_label,
                               exclude_issues,
@@ -90,11 +94,18 @@ add_contributors <- function (repo = ".",
                               num_sections,
                               section_names,
                               format,
-                              alphabetical
-    )
+                              alphabetical)
+        all_repos$ctbs <- rbind(all_repos$ctbs, one_repo$ctbs)
+        all_repos$or <- one_repo$or
+    }
+
+    # Deduplicate if multiple repositories
+    if (length(repo) > 1) {
+        all_repos$ctbs <- all_repos$ctbs[!duplicated(all_repos$ctbs[c("logins")]), ]
+    }
 
     chk <- add_contribs_to_files (
-        ctbs$ctbs, ctbs$or, ncols, format, files,
+        all_repos$ctbs, all_repos$or, ncols, format, files,
         open_issue, force_update
     )
 
@@ -165,7 +176,7 @@ add_contributors_one_repo <- function (
 
     ctbs <- rename_default_sections (ctbs)
 
-    return(list(ctbs, or))
+    return(list(ctbs = ctbs, or = or))
 }
 
 match_type_arg <- function (type) {


### PR DESCRIPTION
This PR adds the option to supply a vector of paths for the `repo` argument. This allows for creating contributor lists across a range of repositories at once (example: for an entire organization). This is in relation to #34.

In this PR the following is changed:
- The contributor list generation per repo is factored out into a separate `add_contributors_one_repo` function
- The `add_contributors` function now takes a vector of `repo` paths (but still works with only one path too)
- If multiple repo's are added, the contributor list is deduplicated

Open questions for consideration are:
- [x] The link to the contributors issues or code are currently based on the last repo scanned. Is this okay or do we want to add links to all the contributed repo's? 
- [x] The contribution counts are currently not summed but based on the first occurrence of the contributor. Is this okay or does it require summation of all contributions across all repo's provided?

I appreciate the opportunity to contribute - the above questions were a bit unforeseen from my end. I am open to any and all suggestions, also if that means ending up not including this code at all. Look forward to hearing what you think and what questions come up 😊  