### PR TITLE
Add rate limit checking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Development
+
+## Minor changes
+
+- Add a rate limit checker for the GitHub API calls. Will warn if rate limit is exceeded.
+
+---
+
 # v 0.1.1
 
 ## Minor changes

--- a/R/github.R
+++ b/R/github.R
@@ -546,14 +546,17 @@ get_gh_contrib_issue <- function (org, repo) {
 #' @noRd
 check_rate_limit <- function () {
     gh_state <- gh::gh_rate_limit()
-    if (gh_state$remaining == 0) {
-        m <- paste0 (
-            "The GitHub rate limit is reached and will",
-            " reset on:\n", gh_state$reset,
-            "\nPlease re-run your query later or scope",
-            " down your query to ensure you stay within",
-            " the limits."
-        )
-        cli::cli_alert_warning (m, wrap = FALSE)
+    limit_warn <- 0.1
+    warn_txt <- NULL
+    if (gh_state$remaining / gh_state$limit < limit_warn) {
+        warn_txt <- "You have used > 90% of your GitHub calls..."
+    } else if (gh_state$remaining == 0) {
+        warn_txt <- "The GitHub rate limit has been reached..."
+    }
+    if (!is.null (warn_txt)) {
+        cli::cli_alert_warning (sprintf(
+                "%s It resets in ~%s minutes.",
+                warn_txt,
+                ceiling(difftime(gh_state$reset, Sys.time(), units = "mins"))))
     }
 }

--- a/R/github.R
+++ b/R/github.R
@@ -296,6 +296,8 @@ get_gh_issue_people <- function (org, repo,
             repo = repo,
             end_cursor = end_cursor
         )
+
+        check_rate_limit()
         dat <- gh::gh_gql (q)
 
         has_next_page <- dat$data$repository$issues$pageInfo$hasNextPage
@@ -446,6 +448,7 @@ get_gh_issue_titles <- function (org, repo) {
             repo = repo,
             end_cursor = end_cursor
         )
+        check_rate_limit()
         dat <- gh::gh_gql (q)
 
         has_next_page <- dat$data$repository$issues$pageInfo$hasNextPage
@@ -536,4 +539,21 @@ get_gh_contrib_issue <- function (org, repo) {
     })
 
     unlist (pings)
+}
+
+#' Check the GitHub rate limit and warn if exceeded.
+#'
+#' @noRd
+check_rate_limit <- function () {
+    gh_state <- gh::gh_rate_limit()
+    if (gh_state$remaining == 0) {
+        m <- paste0 (
+            "The GitHub rate limit is reached and will",
+            " reset on:\n", gh_state$reset,
+            "\nPlease re-run your query later or scope",
+            " down your query to ensure you stay within",
+            " the limits."
+        )
+        cli::cli_alert_warning (m, wrap = FALSE)
+    }
 }

--- a/tests/testthat/getcontribs/api.github.com/graphql-8cf72c-POST.json
+++ b/tests/testthat/getcontribs/api.github.com/graphql-8cf72c-POST.json
@@ -4,7 +4,7 @@
             "issues": {
                 "pageInfo": {
                     "hasNextPage": false,
-                    "endCursor": "Y3Vyc29yOnYyOpHObs1_rQ=="
+                    "endCursor": "Y3Vyc29yOnYyOpK5MjAyMy0wOC0yMVQxMToyMDozMiswMjowMM5uzX-t"
                 },
                 "edges": [
                     {

--- a/tests/testthat/getcontribs/api.github.com/rate_limit-38c41e.json
+++ b/tests/testthat/getcontribs/api.github.com/rate_limit-38c41e.json
@@ -1,0 +1,76 @@
+{
+    "resources": {
+        "core": {
+            "limit": 5000,
+            "used": 22,
+            "remaining": 4978,
+            "reset": 1710753401
+        },
+        "search": {
+            "limit": 30,
+            "used": 0,
+            "remaining": 30,
+            "reset": 1710752737
+        },
+        "graphql": {
+            "limit": 5000,
+            "used": 9,
+            "remaining": 4991,
+            "reset": 1710754258
+        },
+        "integration_manifest": {
+            "limit": 5000,
+            "used": 0,
+            "remaining": 5000,
+            "reset": 1710756277
+        },
+        "source_import": {
+            "limit": 100,
+            "used": 0,
+            "remaining": 100,
+            "reset": 1710752737
+        },
+        "code_scanning_upload": {
+            "limit": 1000,
+            "used": 0,
+            "remaining": 1000,
+            "reset": 1710756277
+        },
+        "actions_runner_registration": {
+            "limit": 10000,
+            "used": 0,
+            "remaining": 10000,
+            "reset": 1710756277
+        },
+        "scim": {
+            "limit": 15000,
+            "used": 0,
+            "remaining": 15000,
+            "reset": 1710756277
+        },
+        "dependency_snapshots": {
+            "limit": 100,
+            "used": 0,
+            "remaining": 100,
+            "reset": 1710752737
+        },
+        "audit_log": {
+            "limit": 1750,
+            "used": 0,
+            "remaining": 1750,
+            "reset": 1710756277
+        },
+        "code_search": {
+            "limit": 10,
+            "used": 0,
+            "remaining": 10,
+            "reset": 1710752737
+        }
+    },
+    "rate": {
+        "limit": 5000,
+        "used": 22,
+        "remaining": 4978,
+        "reset": 1710753401
+    }
+}

--- a/tests/testthat/getcontribs/api/contributors-b0fb04.json
+++ b/tests/testthat/getcontribs/api/contributors-b0fb04.json
@@ -18,7 +18,7 @@
         "received_events_url": "https://api.github.com/users/mpadge/received_events",
         "type": "User",
         "site_admin": false,
-        "contributions": 213
+        "contributions": 214
     },
     {
         "login": "daniellemccool",
@@ -37,6 +37,27 @@
         "repos_url": "https://api.github.com/users/daniellemccool/repos",
         "events_url": "https://api.github.com/users/daniellemccool/events{/privacy}",
         "received_events_url": "https://api.github.com/users/daniellemccool/received_events",
+        "type": "User",
+        "site_admin": false,
+        "contributions": 1
+    },
+    {
+        "login": "olivroy",
+        "id": 52606734,
+        "node_id": "MDQ6VXNlcjUyNjA2NzM0",
+        "avatar_url": "https://avatars.githubusercontent.com/u/52606734?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/olivroy",
+        "html_url": "https://github.com/olivroy",
+        "followers_url": "https://api.github.com/users/olivroy/followers",
+        "following_url": "https://api.github.com/users/olivroy/following{/other_user}",
+        "gists_url": "https://api.github.com/users/olivroy/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/olivroy/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/olivroy/subscriptions",
+        "organizations_url": "https://api.github.com/users/olivroy/orgs",
+        "repos_url": "https://api.github.com/users/olivroy/repos",
+        "events_url": "https://api.github.com/users/olivroy/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/olivroy/received_events",
         "type": "User",
         "site_admin": false,
         "contributions": 1


### PR DESCRIPTION
This PR adds a small function to check the rate limit on the GitHub API. When this hits 0, it will display a warning.

This will help people get feedback on when they are exceeding the rate limit, which can be helpful to scope down the task to be more manageable. 

Pre-discussed in #36. Happy to take feedback as you know your standards for this package best. I tried to stick to how you've previously implemented warnings for sake of package consistency.