### PR TITLE
Fix typo in action name

### DIFF
--- a/.github/workflows/allcontributors.yml
+++ b/.github/workflows/allcontributors.yml
@@ -7,7 +7,7 @@ on:
     # - cron:  '0 12 * * 0' # weekly on Sunday at 12:00
     - cron:  '0 12 1 * *' # monthly on day 1 at 12:00
 
-name: Update allcontributoes
+name: Update allcontributors
 
 jobs:
 


### PR DESCRIPTION
This PR fixes a typo in the name of the `{allcontributors}` action.