### PR TITLE
pad comments with blank lines to match pandoc

### DIFF
--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -429,8 +429,7 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
 
     txt <- c (xtop, xmid, xbottom)
 
-    newlines <- txt [which (!txt %in% x)]
-    changed <- any (nchar (newlines) > 0)
+    changed <- !identical (txt, x)
 
     if (changed) {
         con <- file (filename, "w")

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -357,13 +357,10 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
         }
     }
 
-    # Drop blank lines directly adjoining the list. This prevents those blanks accumulating each time `add_contributors()` re-reads its own output.
-    while (length (xtop) > 0 && xtop [length (xtop)] == "") {
-        xtop <- xtop [-length (xtop)]
-    }
-    while (length (xbottom) > 0 && xbottom [1] == "") {
-        xbottom <- xbottom [-1]
-    }
+    # Drop blank lines directly adjoining the list. This prevents those blanks
+    # accumulating each time `add_contributors()` re-reads its own output.
+    xtop <- trim_nzchar (xtop, start = FALSE)
+    xbottom <- trim_nzchar (xbottom, start = TRUE)
 
     xmid <- NULL
     if (!has_contribs_sec (x)) {

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -357,6 +357,14 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
         }
     }
 
+    # Drop blank lines directly adjoining the list. This prevents those blanks accumulating each time `add_contributors()` re-reads its own output.
+    while (length (xtop) > 0 && xtop [length (xtop)] == "") {
+        xtop <- xtop [-length (xtop)]
+    }
+    while (length (xbottom) > 0 && xbottom [1] == "") {
+        xbottom <- xbottom [-1]
+    }
+
     xmid <- NULL
     if (!has_contribs_sec (x)) {
         sec_fmt <- section_format (x)

--- a/R/add-contributors.R
+++ b/R/add-contributors.R
@@ -368,7 +368,7 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
                 paste0 (rep ("-", sec_fmt), collapse = "")
             )
         }
-        xmid <- c ("", xmid, "")
+        xmid <- c ("", xmid)
     }
 
     xmid <- c (
@@ -378,7 +378,9 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
             "<!-- ALL-CONTRIBUTORS-LIST:START - ",
             "Do not remove or modify this section -->"
         ),
+        "",
         "<!-- prettier-ignore-start -->",
+        "",
         "<!-- markdownlint-disable -->",
         "",
         paste0 (
@@ -418,7 +420,9 @@ add_contribs_to_one_file <- function (ctbs, orgrepo, ncols, format, filename) {
 
     xmid <- c (
         xmid, "<!-- markdownlint-enable -->",
+        "",
         "<!-- prettier-ignore-end -->",
+        "",
         "<!-- ALL-CONTRIBUTORS-LIST:END -->",
         ""
     )

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,6 +16,34 @@ has_contribs_sec <- function (x) {
     return (has_contribs_sec)
 }
 
+#' Trim empty strings from one end of a character vector.
+#'
+#' Removes any empty ("") strings from either the start or the end of `x`,
+#' leaving any empty strings in the interior untouched.
+#'
+#' @param x A character vector.
+#' @param start If `TRUE`, trim empty strings from the start of `x`; otherwise
+#' trim them from the end.
+#' @return `x` with leading or trailing empty strings removed. If every element
+#' is empty, a zero-length vector is returned.
+#' @noRd
+trim_nzchar <- function (x, start = TRUE) {
+
+    # Positions of the non-empty elements; if there are none, drop everything.
+    nz <- which (nzchar (x))
+    if (length (nz) == 0L) {
+        return (x [0])
+    }
+
+    if (start) {
+        # Keep from the first non-empty element (trimming the start)
+        x [seq (min (nz), length (x))]
+    } else {
+        # Keep up to last non-empty element (trimming the end)
+        x [seq_len (max (nz))]
+    }
+}
+
 #' Determine whether markdown sections are single-line hash-format, or two-line
 #' ["title", "---"]-format.
 #' @inheritParams has_contribs_sec


### PR DESCRIPTION
Closes #62.

`add_contributors()` writes the three pairs of HTML comment markers on consecutive lines, which pandoc's `github_document` writer pads with blank lines. 

Changed here to emit the blank lines ourselves so the output already matches what pandoc would produce, and to tightens the change check so existing READMEs in the old format actually get migrated rather than being treated as unchanged. Also the blank line the writer emits before each marker piled up on top of the blank already kept from the previous run, so the file gained a blank line on every pass. Blank lines adjoining the list are now trimmed before reassembly.